### PR TITLE
fix(cli): change return to continue to support component installation with storybook=false

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -153,7 +153,7 @@ export const add = new Command()
             baseColor,
           })
           if (!config.storybook && filePath.includes(".stories.tsx")) {
-            return
+            continue
           }
 
           if (!config.tsx) {


### PR DESCRIPTION
Prior to this update, using the CLI to install components with "storybook": false set in components.json resulted in the installation never completing.